### PR TITLE
Fix: Use sessionStorage and clear storage at startup

### DIFF
--- a/src/lib/onboarding.coffee
+++ b/src/lib/onboarding.coffee
@@ -204,6 +204,9 @@ module.exports = class Onboarding
         @contextToken = contextToken
         @registerToken = registerToken
 
+        if @registerToken
+          @removeLocalData()
+
         onStepChanged and @onStepChanged onStepChanged
         onStepFailed and @onStepFailed onStepFailed
         onDone and @onDone onDone
@@ -268,18 +271,18 @@ module.exports = class Onboarding
     fetchInstanceLocally: ->
         instance
         try
-            instance = JSON.parse window.localStorage.getItem 'instance'
+            instance = JSON.parse window.sessionStorage.getItem 'instance'
         catch e
             instance = null
         return instance
 
 
     saveInstanceLocally: (instance) ->
-        window.localStorage.setItem 'instance', JSON.stringify instance
+        window.sessionStorage.setItem 'instance', JSON.stringify instance
 
 
     removeLocalData: ->
-        window.localStorage.removeItem 'instance'
+        window.sessionStorage.removeItem 'instance'
 
 
     updateInstance: (stepName, data) ->


### PR DESCRIPTION
When a `registerToken` is provided, now clean the session storage. Avoid to have a new instance with sessionStorage relative to previous instance, from which onboarding has not been completed.