### PR TITLE
feat: add intent implementation example in MAIF view

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -98,6 +98,7 @@
     "leave google choice photos": "One-time import of Google Photos",
     "leave google confirm": "Import data",
     "import error": "An error occurs when trying to import your datas. Please try again later from the dedicated app.",
+    "intent service connect": "Sign in",
     "login welcome user": "Welcome %{username}",
     "login welcome anon": "Welcome",
     "login enter your password": "Enter your password to access your Cozy",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -99,6 +99,7 @@
     "leave google confirm": "Import data",
     "import error": "An error occurs when trying to import your datas. Please try again later from the dedicated app.",
     "intent service connect": "Sign in",
+    "intent service error": "An error occured when trying to contact related service. Please try again later.",
     "login welcome user": "Welcome %{username}",
     "login welcome anon": "Welcome",
     "login enter your password": "Enter your password to access your Cozy",

--- a/src/styles/app.styl
+++ b/src/styles/app.styl
@@ -507,6 +507,17 @@ footer
       font-weight bold
       color $blue
 
+      &[aria-busy=true]
+          position relative
+
+          &::after
+              position static
+              width      (16/base-font-size)em
+              height     (16/base-font-size)em
+              margin-left (8/base-font-size)em
+              margin-right (-24/base-font-size)em
+              @extend    $icon-spinner-blue
+
 .service-logo--maif
     box-sizing border-box
     width 4.25rem

--- a/src/styles/app.styl
+++ b/src/styles/app.styl
@@ -288,7 +288,6 @@ button
     &[aria-busy=true]
 
         &::after
-            position static
             width      (16/base-font-size)em
             height     (16/base-font-size)em
             margin-left (8/base-font-size)em
@@ -511,11 +510,6 @@ footer
       &[aria-busy=true]
 
           &::after
-              position static
-              width      (16/base-font-size)em
-              height     (16/base-font-size)em
-              margin-left (8/base-font-size)em
-              margin-right (-24/base-font-size)em
               @extend    $icon-spinner-blue
 
 .service-logo--maif

--- a/src/styles/app.styl
+++ b/src/styles/app.styl
@@ -267,6 +267,7 @@ select
 [role=button]
 button
     // mutualize behavior between button and a
+    position relative
     box-sizing        border-box
     border            0
     display           block
@@ -285,7 +286,6 @@ button
         cursor  default
 
     &[aria-busy=true]
-        position relative
 
         &::after
             position static
@@ -498,6 +498,7 @@ footer
     background-color $grey-11
 
     button
+      position relative
       width auto
       min-height auto
       padding 0
@@ -508,7 +509,6 @@ footer
       color $blue
 
       &[aria-busy=true]
-          position relative
 
           &::after
               position static

--- a/src/styles/app.styl
+++ b/src/styles/app.styl
@@ -513,3 +513,43 @@ footer
     height 4.25rem
     padding .5rem .5rem .75rem
     background-color $maif
+
+
+// Modal
+.modal-overlay
+  position         fixed
+  top              0
+  left             0
+  width            100vw
+  height           100vh
+  z-index          20
+  overflow         hidden
+  background-color rgba(0,0,0,.5)
+  display          flex
+  align-items      center
+  justify-content  center
+  transition       background-color .3s
+
+  .modal
+    margin-top    0px
+    max-width     800px
+    width         80%
+    height        80%
+    background    white
+    border-radius 1em
+    box-shadow    0 1px 3px .7 black
+    transition    margin-top .3s
+
+  &[aria-hidden=true]
+    background-color rgba(0,0,0,0)
+
+    .modal
+      margin-top 2000px
+
+
+// Intent iframe in a modal
+.coz-intent
+  border        none
+  border-radius 1em
+  width         100%
+  height        100%

--- a/src/styles/app.styl
+++ b/src/styles/app.styl
@@ -497,7 +497,6 @@ footer
     background-color $grey-11
 
     button
-      position relative
       width auto
       min-height auto
       padding 0
@@ -507,10 +506,8 @@ footer
       font-weight bold
       color $blue
 
-      &[aria-busy=true]
-
-          &::after
-              @extend    $icon-spinner-blue
+      &[aria-busy=true]::after
+        @extend $icon-spinner-blue
 
 .service-logo--maif
     box-sizing border-box

--- a/src/styles/cozy-ui/icons.styl
+++ b/src/styles/cozy-ui/icons.styl
@@ -39,7 +39,7 @@ $icon-36
 // icon's properties
 // ========================================================
 $spin
-    position absolute
+    position static
     top 50%
     left 50%
     transform translateX(-50%) translateY(-50%)

--- a/src/views/modal.coffee
+++ b/src/views/modal.coffee
@@ -1,0 +1,73 @@
+{ItemView} = require 'backbone.marionette'
+Backbone = require 'backbone'
+
+key = {
+  ESC: 27
+}
+
+
+module.exports = class ModalView extends ItemView
+    template: require './templates/modal'
+
+    ui:
+        modalOverlay: '.modal-overlay'
+        contentWrapper: '.modal'
+
+    events:
+        'click @ui.contentWrapper': 'preventClick'
+        'keyup @ui.modalOverlay': 'onKeyUp'
+
+
+    initialize: (options) ->
+        @onHide = options.onHide
+        this.render options.item
+
+
+    getContentWrapper: ->
+        return @ui.contentWrapper.get(0)
+
+
+    onRender: (item) ->
+        @document = @el.ownerDocument
+        @document.body.appendChild @el
+
+        @document.addEventListener 'keyup', @hide.bind(@)
+
+        contentWrapperElement = @ui.contentWrapper.get(0)
+
+        # Wait for content like iframe to be loaded
+        observer = new MutationObserver (event) =>
+            $iframe = @$ 'iframe'
+            if $iframe.length
+                $iframe.on 'load', (event) =>
+                    @show()
+            else
+                @show()
+
+        observer.observe contentWrapperElement, childList: true
+
+
+    preventClick: (event) ->
+        event.stopPropagation()
+
+
+    onKeyUp: (event) ->
+        if event.keyCode is key.ESC
+            hide()
+
+
+    dispose: () ->
+        @document.body.removeChild @el
+
+
+    hide: () ->
+        @$el.one 'transitionend', () =>
+            if typeof @onHide is 'function'
+                @onHide()
+            @dispose()
+
+        @ui.modalOverlay.attr 'aria-hidden', 'true'
+
+    show: () ->
+        @ui.modalOverlay.attr 'aria-hidden', 'false'
+        @ui.modalOverlay.on 'click', () => @hide()

--- a/src/views/modal.coffee
+++ b/src/views/modal.coffee
@@ -35,7 +35,7 @@ module.exports = class ModalView extends ItemView
 
         contentWrapperElement = @ui.contentWrapper.get(0)
 
-        # Wait for content like iframe to be loaded
+        # Observe and wait content injection before showing the modal
         observer = new MutationObserver (event) =>
             $iframe = @$ 'iframe'
             if $iframe.length

--- a/src/views/steps/subviews/service.coffee
+++ b/src/views/steps/subviews/service.coffee
@@ -9,10 +9,10 @@ module.exports = class ServiceView extends ItemView
     className: 'service'
 
     ui:
-        connect: '[role=connect]'
+        connect: '.connect'
 
     events:
-      'click [role=connect]': 'onConnect'
+      'click .connect': 'onConnect'
 
 
     initialize: (options) ->

--- a/src/views/steps/subviews/service.coffee
+++ b/src/views/steps/subviews/service.coffee
@@ -1,0 +1,81 @@
+{ItemView} = require 'backbone.marionette'
+_ = require 'underscore'
+
+ModalView = require '../../modal'
+
+module.exports = class ServiceView extends ItemView
+    template: require '../../templates/service'
+
+    className: 'service'
+
+    ui:
+        connect: '[role=connect]'
+
+    events:
+      'click [role=connect]': 'onConnect'
+
+
+    initialize: (options) ->
+        @service = options.service
+        @intent = options.intent
+
+        @onIntentStart = () =>
+            if typeof options.onIntentSuccess is 'function'
+                options.onIntentStart()
+
+        @onIntentSuccess = (doc) =>
+            if typeof options.onIntentSuccess is 'function'
+                options.onIntentSuccess doc
+
+        @onIntentError = (error) =>
+            if typeof options.onIntentError is 'function'
+                options.onIntentError error
+
+        @onIntentEnd = () =>
+            if typeof options.onIntentEnd is 'function'
+                options.onIntentEnd()
+
+
+    serializeData: () ->
+        _.extend super,
+            @service
+
+
+    onConnect: () ->
+        @onIntentStart()
+        @setBusy true
+
+        modal = new ModalView \
+            onHide: () =>
+                @onIntentEnd()
+                @setBusy false
+
+
+        cozy.client.intents
+            .create @intent.action, @intent.type
+            .start modal.getContentWrapper()
+            .then (doc) =>
+                @onIntentSuccess doc
+            .catch (error) =>
+                @onIntentError error
+            .then () =>
+                @setBusy false
+
+
+    setBusy: (busy) ->
+        if busy
+            @disableConnect()
+            @ui.connect.attr 'aria-busy', true
+        else
+            @enableConnect()
+            @ui.connect.removeAttr 'aria-busy'
+
+
+    enableConnect: () ->
+        @ui.connect.removeAttr 'disabled'
+        @ui.connect.removeAttr 'aria-disabled'
+
+
+    disableConnect: () ->
+        @ui.connect.attr 'disabled', 'disabled'
+        @ui.connect.attr 'aria-disabled', 'true'

--- a/src/views/steps/subviews/service.coffee
+++ b/src/views/steps/subviews/service.coffee
@@ -20,7 +20,7 @@ module.exports = class ServiceView extends ItemView
         @intent = options.intent
 
         @onIntentStart = () =>
-            if typeof options.onIntentSuccess is 'function'
+            if typeof options.onIntentStart is 'function'
                 options.onIntentStart()
 
         @onIntentSuccess = (doc) =>

--- a/src/views/steps/subviews/service.coffee
+++ b/src/views/steps/subviews/service.coffee
@@ -55,8 +55,10 @@ module.exports = class ServiceView extends ItemView
             .create @intent.action, @intent.type
             .start modal.getContentWrapper()
             .then (doc) =>
+                modal.hide()
                 @onIntentSuccess doc
             .catch (error) =>
+                modal.hide()
                 @onIntentError error
             .then () =>
                 @setBusy false

--- a/src/views/templates/modal.jade
+++ b/src/views/templates/modal.jade
@@ -1,0 +1,2 @@
+.modal-overlay(aria-hidden="true")
+  .modal

--- a/src/views/templates/service.jade
+++ b/src/views/templates/service.jade
@@ -1,0 +1,6 @@
+if figureid
+  figure.service-logo(class=service)
+    svg: use(xlink:href=figureid)
+.service-name=t(name)
+.service-actions
+  button(role='connect')= t('intent service connect')

--- a/src/views/templates/service.jade
+++ b/src/views/templates/service.jade
@@ -3,4 +3,4 @@ if figureid
     svg: use(xlink:href=figureid)
 .service-name=t(name)
 .service-actions
-  button(role='connect')= t('intent service connect')
+  button.connect= t('intent service connect')

--- a/src/views/templates/view_steps_maif.jade
+++ b/src/views/templates/view_steps_maif.jade
@@ -7,13 +7,6 @@ block header
 block region
     p= t('step maif description line 1')
     div(class="services")
-      .service
-        if figureid
-          figure.service-logo(class=service)
-            svg: use(xlink:href=figureid)
-        .service-name= t('step maif service')
-        .service-actions
-          button= t('step maif connect')
 
 block controls
     button(class="next", aria-disabled="true", disabled="disabled")= t('step maif next')

--- a/src/views/templates/view_steps_maif.jade
+++ b/src/views/templates/view_steps_maif.jade
@@ -16,6 +16,6 @@ block region
           button= t('step maif connect')
 
 block controls
-    button(class="next", aria-disabled="true")= t('step maif next')
+    button(class="next", aria-disabled="true", disabled="disabled")= t('step maif next')
     p(class="pass")
       a(href="#")= t('step maif pass')


### PR DESCRIPTION
This PR takes the existing MAIF view in onboarding and implements an example of intent usage into it.
The content of this PR is:
* Adding a modal in onboarding
* Use a new ServiceView to handle service blocks like MAIF, it will be useful for next services (ping @lespacedunmatin)
* Impements intent call in the service view.

To test with an demo application: 
```bash
cozy-stack apps install example git://github.com/gregorylegarec/cozy-intent-example.git#build  --domain cozy.tools:8080 