### PR TITLE
feat: enable piwik tracking

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -8,7 +8,9 @@ module.exports = {
   plugins: [
     new webpack.DefinePlugin({
       __SERVER__: JSON.stringify('http://app.cozy.tools'),
-      __STACK_ASSETS__: false
+      __STACK_ASSETS__: false,
+      __PIWIK_TRACKER_URL__: JSON.stringify('https://piwik.cozycloud.cc/piwik.php'),
+      __PIWIK_SITEID__: 11
     }),
     new webpack.ProvidePlugin({
       'cozy.client': 'cozy-client-js/dist/cozy-client.js'

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -20,7 +20,9 @@ module.exports = {
       __SERVER__: false,
       __DEVELOPMENT__: false,
       __DEVTOOLS__: false,
-      __STACK_ASSETS__: true
+      __STACK_ASSETS__: true,
+      __PIWIK_TRACKER_URL__: JSON.stringify('https://piwik.cozycloud.cc/piwik.php'),
+      __PIWIK_SITEID__: 11
     })
   ]
 }

--- a/src/application.coffee
+++ b/src/application.coffee
@@ -36,6 +36,9 @@ class App extends Application
           cozy.client.init \
             cozyURL: "//#{applicationElement.dataset.cozyStack}",
             token: @contextToken
+            
+        tracker = Piwik.getTracker(__PIWIK_TRACKER_URL__, __PIWIK_SITEID__)
+        tracker.enableHeartBeatTimer()
 
         @on 'start', (options)=>
             @layout = new AppLayout()
@@ -60,6 +63,9 @@ class App extends Application
     # changed.
     # @param step Step instance
     handleStepChanged: (onboarding, step) ->
+        tracker = Piwik.getTracker(__PIWIK_TRACKER_URL__, __PIWIK_SITEID__)
+        tracker.setCustomUrl step.name
+        tracker.trackPageView()
         @showStep onboarding, step
 
 

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -28,6 +28,7 @@
 <% if (__STACK_ASSETS__) { %>
 {{.CozyClientJS}}
 <% } %>
+<script src="//{{.Domain}}/assets/js/piwik.js" defer></script>
 <% _.forEach(htmlWebpackPlugin.files.js, function(file) { %>
   <script src="<%- file %>" defer></script>
 <% }); %>


### PR DESCRIPTION
Only thing worth pointing out: since the app doesn't *really* change the URLs, I'm manually firing fake page views using the steps title as a URL (ie. `http://app.cozy.tools:8080/Infos`).