### PR TITLE
chore: keep the build dir on clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "src/main.jsx",
   "scripts": {
     "build": "NODE_ENV=production webpack --config webpack.config.js --bail",
-    "clean": "rm -rf build",
+    "clean": "rm -rf build/*",
     "copy:manifest": "install -m0644 package.json README.md LICENSE build",
     "deploy": "git-directory-deploy --username Cozy --email contact@cozycloud.cc --directory build/ --branch build --repo=https://$GITHUB_TOKEN@github.com/cozy/cozy-onboarding-v3.git",
     "tx": "tx pull --all || true",


### PR DESCRIPTION
A tiny change, but pretty cool: with this, the docker instance can keep running even if you restart the watcher.