### PR TITLE
fix: use a single tracker instance

### DIFF
--- a/src/application.coffee
+++ b/src/application.coffee
@@ -38,15 +38,15 @@ class App extends Application
             token: @contextToken
 
         try
-            tracker = Piwik.getTracker(__PIWIK_TRACKER_URL__, __PIWIK_SITEID__)
-            tracker.enableHeartBeatTimer()
+            @tracker = Piwik.getTracker(__PIWIK_TRACKER_URL__, __PIWIK_SITEID__)
+            @tracker.enableHeartBeatTimer()
             
             userId = @domain
             indexOfPort = userId.indexOf(':')
             if indexOfPort >= 0 then userId = userId.substring(0, indexOfPort)
             
-            tracker.setUserId(userId)
-            tracker.setCustomDimension(__PIWIK_DIMENSION_ID_APP__, applicationElement.dataset.cozyAppName)
+            @tracker.setUserId(userId)
+            @tracker.setCustomDimension(__PIWIK_DIMENSION_ID_APP__, applicationElement.dataset.cozyAppName)
         catch error
           console.warn and console.warn 'Unable to initialize Piwik.'
 
@@ -74,12 +74,9 @@ class App extends Application
     # changed.
     # @param step Step instance
     handleStepChanged: (onboarding, step) ->
-        try
-            tracker = Piwik.getTracker(__PIWIK_TRACKER_URL__, __PIWIK_SITEID__)
-            tracker.setCustomUrl step.name
-            tracker.trackPageView()
-        catch error
-            console.warn and console.warn 'Unable to use Piwik.'
+        if (@tracker)
+            @tracker.setCustomUrl step.name
+            @tracker.trackPageView()
 
         @showStep onboarding, step
 


### PR DESCRIPTION
Calling `getTracker` a second time in `handleSepChanged` returned a second instance, without the user id and the app.