### PR TITLE
ONB-27 | Fix onboarding tiles

### DIFF
--- a/src/styles/app.styl
+++ b/src/styles/app.styl
@@ -35,9 +35,17 @@ main > div
 
 
 .main-wrapper
-    flex       0 1 30em
+    flex       1
     margin     auto
     padding    3em 1em
+
+
+    header
+    [role=region] form
+    footer
+        max-width 30em
+        text-align center
+        margin auto
 
 
 header
@@ -89,6 +97,7 @@ header
         line-height 1.5
         &:first-child
             margin 1em 0
+
 
 
 .agreements
@@ -492,7 +501,8 @@ footer
     margin-right -.75em
 
 .service
-    flex 1 9em
+    flex 1 14em
+    max-width 14em
     margin .75em
     border 1px solid $grey-10
     border-radius 4px


### PR DESCRIPTION
This PR fixes #51 by allowing services tiles to flow properly on large screen instead of staying in two columns. To avoid arbitrary media-queries, it lets the tiles take space (see attached screenshots).
![img-2017-06-13-112819](https://user-images.githubusercontent.com/471486/27078129-ca2ee2cc-5032-11e7-8d1b-641f6e4b718b.png)
![img-2017-06-13-112908](https://user-images.githubusercontent.com/471486/27078140-d6195db0-5032-11e7-887e-4b54c87eee08.png)
![img-2017-06-13-112923](https://user-images.githubusercontent.com/471486/27078147-dc90d9fc-5032-11e7-8410-33bc22c9f9b6.png)


