### PR TITLE
Fix errors margin in services step

### DIFF
--- a/src/styles/app.styl
+++ b/src/styles/app.styl
@@ -338,6 +338,9 @@ button
 .errors
     color  $red
 
+    &:empty
+        display  none
+
 // password strength bar
 progress
     width         100%

--- a/src/views/step.coffee
+++ b/src/views/step.coffee
@@ -61,8 +61,7 @@ module.exports = class StepView extends LayoutView
 
     showError: (error) ->
         @ui.errors.html t if error and error.message then error.message else error
-        @ui.errors.show()
 
 
     hideError: () ->
-        @ui.errors.hide()
+        @ui.errors.empty()


### PR DESCRIPTION
This PR fixes a bug that make margins inconsistents between services tiles and the _go on_ button. It was due to the `errors` wrapper, that has margins, which in DOM by default, but empty. When clicking on a service, this `errors` wrapper is `display: none` (because there's no errors), so the margins disappear and make the _go on_ button step up.

It fixes it by emptying the wrapper when calling the `hide` method, and use the `:empty` CSS selector to display:none` it. 